### PR TITLE
Faster ToOctave() implementations

### DIFF
--- a/src/Octave.NET.Tests/OctaveDoubleExtensionsTests.cs
+++ b/src/Octave.NET.Tests/OctaveDoubleExtensionsTests.cs
@@ -19,6 +19,19 @@ namespace Octave.NET.Tests
         }
 
         [TestMethod]
+        public void EmptyVectorToOctave_ReturnsCorrectResult()
+        {
+            //arrange
+            var input = new double[0];
+
+            //act
+            var res = input.ToOctave();
+
+            //assert
+            Assert.AreEqual(res, "[]");
+        }
+
+        [TestMethod]
         public void MatrixToOctave_ReturnsCorrectResult()
         {
             //arrange
@@ -33,6 +46,19 @@ namespace Octave.NET.Tests
 
             //assert
             Assert.AreEqual(res, "[1 2 3;3 2 1]");
+        }
+
+        [TestMethod]
+        public void EmptyMatrixToOctave_ReturnsCorrectResult()
+        {
+            //arrange
+            var input = new double[0][];
+
+            //act
+            var res = input.ToOctave();
+
+            //assert
+            Assert.AreEqual(res, "[]");
         }
     }
 }

--- a/src/Octave.NET/OctaveDoubleExtensions.cs
+++ b/src/Octave.NET/OctaveDoubleExtensions.cs
@@ -1,18 +1,23 @@
 ﻿using System.Globalization;
-using System.Linq;
+using System.Text;
 
 namespace Octave.NET
 {
     public static class OctaveDoubleExtensions
     {
-        private static string BuildVector(double[] vector)
+        private static StringBuilder AppendVector(this StringBuilder stringBuilder, double[] vector)
         {
-            return vector.Select(x => x.ToString(CultureInfo.InvariantCulture)).Aggregate((a, b) => $"{a} {b}");
-        }
+            if (vector.Length > 0)
+            {
+                foreach (double d in vector)
+                {
+                    stringBuilder.Append(d.ToString(CultureInfo.InvariantCulture)).Append(' ');
+                }
 
-        private static string BuildMatrix(double[][] matrix)
-        {
-            return matrix.Select(BuildVector).Aggregate((a, b) => $"{a};{b}");
+                stringBuilder.Length--;
+            }
+
+            return stringBuilder;
         }
 
         /// <summary>
@@ -20,7 +25,7 @@ namespace Octave.NET
         /// </summary>
         public static string ToOctave(this double[] vector)
         {
-            return $"[{BuildVector(vector)}]";
+            return new StringBuilder().Append('[').AppendVector(vector).Append(']').ToString();
         }
 
         /// <summary>
@@ -28,7 +33,19 @@ namespace Octave.NET
         /// </summary>
         public static string ToOctave(this double[][] matrix)
         {
-            return $"[{BuildMatrix(matrix)}]";
+            StringBuilder stringBuilder = new StringBuilder().Append('[');
+
+            if (matrix.Length > 0)
+            {
+                foreach (double[] vector in matrix)
+                {
+                    stringBuilder.AppendVector(vector).Append(';');
+                }
+
+                stringBuilder.Length--;
+            }
+
+            return stringBuilder.Append(']').ToString();
         }
     }
 }


### PR DESCRIPTION
### Why?
The current combination of aggregations and formatting is rather slow, in fact an array of 80.000 randomly generated doubles took about 40 seconds to be formatted into an octave vector string. This alternative implementation only took 47 milliseconds to create the same string. I initially wanted to test the difference on an array filled with zeroes of size 4.000.000, however after about 20 minutes I decided it was taking too long, while the implementation in this pull request only took 614 milliseconds.

### What?
The `.ToOctave()` methods have been implemented with a `StringBuilder` loop which is considerably faster/more scalable than the current implementation present in the master branch.