### PR TITLE
Minus infinity in matrix potential fix

### DIFF
--- a/src/Octave.NET.Tests/OctaveStringExtensionsTests.cs
+++ b/src/Octave.NET.Tests/OctaveStringExtensionsTests.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Octave.NET.Tests
+{
+    [TestClass]
+    public class OctaveStringExtensionsTests
+    {
+        [TestMethod]
+        public void StringAsScalar_ReturnsCorrectResult()
+        {
+            //arrange
+            var input = "ans = 34";
+
+            //act
+            var res = input.AsScalar();
+
+            //assert
+            Assert.AreEqual(res, 34);
+        }
+
+        [TestMethod]
+        public void StringInfinityAsScalar_ReturnsCorrectResult()
+        {
+            //arrange
+            var input = "ans = Inf";
+
+            //act
+            var res = input.AsScalar();
+
+            //assert
+            Assert.AreEqual(res, double.MaxValue);
+        }
+
+        [TestMethod]
+        public void StringMinusInfinityAsScalar_ReturnsCorrectResult()
+        {
+            //arrange
+            var input = "ans = -Inf";
+
+            //act
+            var res = input.AsScalar();
+
+            //assert
+            Assert.AreEqual(res, double.MinValue);
+        }
+
+        [TestMethod]
+        public void StringAsVector_ReturnsCorrectResult()
+        {
+            //arrange
+            var input = "ans = 1 2 3";
+
+            //act
+            var res = input.AsVector();
+
+            //assert
+            Assert.AreEqual(res.Length, 3);
+            Assert.AreEqual(res[0], 1);
+            Assert.AreEqual(res[1], 2);
+            Assert.AreEqual(res[2], 3);
+        }
+
+        [TestMethod]
+        public void StringWithInfinitiesAsVector_ReturnsCorrectResult()
+        {
+            //arrange
+            var input = "ans = 1 -Inf Inf";
+
+            //act
+            var res = input.AsVector();
+
+            //assert
+            Assert.AreEqual(res.Length, 3);
+            Assert.AreEqual(res[0], 1);
+            Assert.AreEqual(res[1], double.MinValue);
+            Assert.AreEqual(res[2], double.MaxValue);
+        }
+
+        [TestMethod]
+        public void StringAsMatrix_ReturnsCorrectResult()
+        {
+            //arrange
+            var input = $"ans = 4 5 6{Environment.NewLine}7 8 9";
+
+            //act
+            var res = input.AsMatrix();
+
+            //assert
+            Assert.AreEqual(res.Length, 2);
+            Assert.AreEqual(res[0].Length, 3);
+            Assert.AreEqual(res[0][0], 4);
+            Assert.AreEqual(res[0][1], 5);
+            Assert.AreEqual(res[0][2], 6);
+            Assert.AreEqual(res[1].Length, 3);
+            Assert.AreEqual(res[1][0], 7);
+            Assert.AreEqual(res[1][1], 8);
+            Assert.AreEqual(res[1][2], 9);
+        }
+    }
+}

--- a/src/Octave.NET/OctaveStringExtensions.cs
+++ b/src/Octave.NET/OctaveStringExtensions.cs
@@ -60,6 +60,9 @@ namespace Octave.NET
 
         private static double ParseDouble(string number)
         {
+            if (number.Contains("-Inf"))
+                return double.MinValue;
+
             if (number.Contains("Inf"))
                 return double.MaxValue;
 

--- a/src/Octave.NET/OctaveStringExtensions.cs
+++ b/src/Octave.NET/OctaveStringExtensions.cs
@@ -10,12 +10,6 @@ namespace Octave.NET
         {
             input = CleanInput(input);
 
-            if (input.EndsWith("-Inf"))
-                return double.MinValue;
-
-            if (input.EndsWith("Inf"))
-                return double.MaxValue;
-
             return ParseDouble(input);
         }
 


### PR DESCRIPTION
#### Why?
Currently when a result from Octave is being parsed as a scalar `-Inf` becomes `double.MinValue`. However, when `-Inf` is within a matrix or vector it becomes `double.MaxValue`. I doubt this was intentional and I assumed it was supposed to be `double.MinValue` as well, to be able to differentiate from `Inf`.

#### What?
- Added an extra check to the `ParseDouble()` method.
- Added test cases for the `OctaveStringExtensions` class, which include cases for `Inf` and `-Inf`.